### PR TITLE
fix: tests and recover InterRep syncer

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,7 @@
     "sass": "^1.43.4",
     "styled-components": "^5.3.3",
     "test-pcd-semaphore-group-pcd": "^0.7.2",
-    "test-zk-chat-client": "1.0.21",
+    "test-zk-chat-client": "1.0.22",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
         "mongoose": "5.13.13",
         "node-schedule": "^2.1.0",
         "redis": "^3.1.2",
-        "test-zk-chat-server": "1.0.26",
+        "test-zk-chat-server": "1.0.28",
         "uWebSockets.js": "uNetworking/uWebSockets.js#v20.4.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15727,10 +15727,10 @@ test-pcd-semaphore-signature-pcd@^0.4.3:
     react "^17.0.2"
     typescript "^4.5.2"
 
-test-zk-chat-client@1.0.21:
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/test-zk-chat-client/-/test-zk-chat-client-1.0.21.tgz#455dc95ede37f5d1f4ad223ac0fee0b32d7e50a8"
-  integrity sha512-0tX098HYkgs5iKZMoSRmFaGBdL6qP+bdxI6ZyMm5Evb1gf+iR420xDGFkXPxJ4GwWflBBPX7NDZWvpayid6+HQ==
+test-zk-chat-client@1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/test-zk-chat-client/-/test-zk-chat-client-1.0.22.tgz#387a1e5bade0b00f3625e4905f167e2d7d0d3dd7"
+  integrity sha512-qZhnQVkxX95nEE3QRO9UJJyw+/HPWs2dG7/w4+KnQlrSLxToLwHd/7lBbeo5YppruF6QvR0J9fr3Os4ww+8Spg==
   dependencies:
     "@zk-kit/identity" "^1.4.1"
     "@zk-kit/protocols" "^1.8.2"
@@ -15743,10 +15743,10 @@ test-zk-chat-client@1.0.21:
     uuid "^8.3.2"
     ws "^8.3.0"
 
-test-zk-chat-server@1.0.26:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/test-zk-chat-server/-/test-zk-chat-server-1.0.26.tgz#f3bba5d23ea089dbf7ffb5d137e7b537c6614fc2"
-  integrity sha512-WBWBVj+6GMsYjfvOCVHJ8AWDFOH48GCi5GNfMOJPw+CV8zWcHAAy1ltajr59oACNcp69Snf06YsDRWqlZKpNDw==
+test-zk-chat-server@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/test-zk-chat-server/-/test-zk-chat-server-1.0.28.tgz#46e1e242526c4ff87876a1a1c2e890ea834c7d04"
+  integrity sha512-M90r/zZ/YKKr7JjehC2Nyy89rg3yUtLhbjqq5HnS3U01IveDfMDD86AxSTyGMNq+Wgdojhtf3UkYCTHOYwCx7g==
   dependencies:
     "@zk-kit/identity" "^1.4.1"
     "@zk-kit/protocols" "^1.8.2"
@@ -16146,7 +16146,7 @@ typescript@^4.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-"uWebSockets.js@github:uNetworking/uWebSockets.js#v20.4.0", uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0:
+uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0:
   version "20.4.0"
   resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/65f39bdff763be3883e6cf18e433dd4fec155845"
 

--- a/zk-chat-client-lib/package.json
+++ b/zk-chat-client-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "test-zk-chat-client",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "description": "ZK Chat client library",
     "main": "dist/index.node.js",
     "repository": "https://github.com/njofce/zk-chat",

--- a/zk-chat-server-lib/package.json
+++ b/zk-chat-server-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "test-zk-chat-server",
-    "version": "1.0.26",
+    "version": "1.0.28",
     "description": "ZK Chat server library",
     "main": "dist/index.node.js",
     "repository": "https://github.com/njofce/zk-chat",

--- a/zk-chat-server-lib/src/create_server.ts
+++ b/zk-chat-server-lib/src/create_server.ts
@@ -11,7 +11,6 @@ import SocketServer from "./communication/socket/socket_server";
 import MessageHandlerService from "./services/message_handler_service";
 import NodeSynchronizer from "./communication/node_sync";
 import SemaphoreSynchronizer from "./semaphore";
-import InterRepSynchronizer from "./interrep";
 import Hasher from "./util/hasher";
 import UserService from "./services/user.service";
 import KeyExchangeService from "./services/key_exchange_service";
@@ -49,7 +48,7 @@ const initZKChatServer = async (config: IZKServerConfig) => {
 
     const keyExchangeService: KeyExchangeService = createKeyExchangeService(config, userService, keyExchangeRequestStatsService, new Hasher());
 
-    const interRepSynchronizer = new InterRepSynchronizer(redisPubSub, groupService, userService, config);
+    const interRepSynchronizer = new SemaphoreSynchronizer(redisPubSub, groupService, userService, config);
     await interRepSynchronizer.sync();
 
     const messageHandler: MessageHandlerService = createMessageHandler(config, redisPubSub, userService, requestStatsService);

--- a/zk-chat-server-lib/src/interrep/api.ts
+++ b/zk-chat-server-lib/src/interrep/api.ts
@@ -1,59 +1,48 @@
 import axios from 'axios';
 import { IGroupMember, IInterRepGroupV2 } from "./interfaces";
-import { Group } from "@semaphore-protocol/group";
-
-const DEFAULT_DEPTH = 16
-const DEFAULT_GROUP_ID = "1"
-
 /**
  * Returns only the supported groups
  */
 const getAllGroups = async (baseUrl: string): Promise<IInterRepGroupV2[]> => {
-    const membersRaw = await getMembersForGroup(baseUrl);
-    const members = membersRaw.map((member: IGroupMember) => member.identityCommitment);
-    const group = new Group(DEFAULT_GROUP_ID, DEFAULT_DEPTH);
-    group.addMembers(members);
-    const merkleRoot = String(group.root);
-    console.log("!@# getAllGroups: members.length=", members.length, ", merkleRoot=", merkleRoot);
-    return [
-        {
-            root: merkleRoot,
-            name: 'Zuzalu Participants',
-            provider: "Semaphore",
-            // NOTE: (Kevin) size and number of leaves are the same since
-            // members should not be removed in Zuzalu?
-            size: members.length,
-            numberOfLeaves: members.length,
-        },
-    ]
-};
-
-/**
- * Returns an ordered list of members in the group.
- */
-const getMembersForGroup = async (baseUrl: string): Promise<IGroupMember[]> => {
-    const id = DEFAULT_GROUP_ID
-    const url = baseUrl + `/semaphore/${id}`;
-    console.log("!@# getMembersForGroup: url = ", url)
     try {
         const res = await axios({
             method: 'GET',
             timeout: 5000,
-            url,
+            url: baseUrl + "/groups",
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
             }
         });
-        const members: IGroupMember[] = res.data.members.map((member: string, index: number) => {
-            return {
-                index,
-                identityCommitment: member
-            }
-        })
-        return members;
+        return res.data.data;
     } catch (e) {
-        console.log("Exception while loading members of the group: ", id);
+        return []
+    }
+};
+
+/**
+ * Returns an ordered list of members in the group.
+ */
+const getMembersForGroup = async (baseUrl: string, provider: string, name: string, limit: number = 100, offset: number = 0): Promise<IGroupMember[]> => {
+    try {
+        const res = await axios({
+            method: 'GET',
+            timeout: 5000,
+            url: baseUrl + `/groups/${provider}/${name}/members?limit=${limit}&offset=${offset}`,
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            }
+        });
+        
+        return res.data.data.map((el, index) => {
+            return {
+                index: offset + index,
+                identityCommitment: el
+            }
+        });
+    } catch (e) {
+        console.log("Exception while loading members of the group: ", provider, name);
         return [];
     }
 }
@@ -61,9 +50,23 @@ const getMembersForGroup = async (baseUrl: string): Promise<IGroupMember[]> => {
 /**
  * Returns an ordered list of the leaf indexes of removed members in the group.
  */
-const getRemovedMembersForGroup = async (baseUrl: string): Promise<number[]> => {
-    // NOTE: (Kevin) I don't think we need this function for Zuzalu
-    return [];
+const getRemovedMembersForGroup = async (baseUrl: string, provider: string, name: string, limit: number = 100, offset: number = 0): Promise<number[]> => {
+    try {
+        const res = await axios({
+            method: 'GET',
+            timeout: 5000,
+            url: baseUrl + `/groups/${provider}/${name}/removed-members?limit=${limit}&offset=${offset}`,
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            }
+        });
+
+        return res.data.data;
+    } catch (e) {
+        console.log("Exception while loading removed members of the group: ", provider, name);
+        return [];
+    }
 }
 
 const apiFunctions = {

--- a/zk-chat-server-lib/src/interrep/index.ts
+++ b/zk-chat-server-lib/src/interrep/index.ts
@@ -8,12 +8,12 @@ import interRepFunctions from "./api";
 import { IZKServerConfig } from "../types";
 
 /**
- * Synchronize the InterRep tree with the local database.
- *
+ * Synchronize the InterRep tree with the local database. 
+ * 
  * The algorithms first retrieves all groups from InterRep,
  * without any pagination assuming the number of existing groups is lower than 100. After that, it tries to check
  * the status of each loaded group with the group stored in the database. For any group which doesn't exist in the
- * database, or the size of the group stored in the database is lower than the size of the retrieved group,
+ * database, or the size of the group stored in the database is lower than the size of the retrieved group, 
  * the members are retrieved, using pagination, stored in the database, and the respective group is updated in the
  * database.
  */
@@ -89,6 +89,7 @@ class InterRepSynchronizer {
                     try {
                         // Remove members from the tree
                         await this.userService.removeUsersByIndexes(indexesOfRemovedMembers, groupInDb.group_id);
+                        
                         // Update group size in DB
                         await this.groupService.updateSize(g_id, g.size);
 
@@ -107,12 +108,39 @@ class InterRepSynchronizer {
     }
 
     private async loadGroupMembersWithPagination(provider: string, name: string, offset: number, to: number): Promise<IGroupMember[]> {
-        const members: IGroupMember[] = await interRepFunctions.getMembersForGroup(this.config.interepUrl);
-        return members.slice(offset, to);
+        let loadedMembers: IGroupMember[] = [];
+
+        const limit: number = 100;
+
+        let members: IGroupMember[] = await interRepFunctions.getMembersForGroup(this.config.interepUrl, provider, name, limit, offset);
+
+        loadedMembers = loadedMembers.concat(members);
+
+        while (members.length + limit <= to) {
+            offset += limit;
+            members = await interRepFunctions.getMembersForGroup(this.config.interepUrl, provider, name, limit, offset);
+            loadedMembers = loadedMembers.concat(members);
+        }
+
+        return loadedMembers;
     }
 
     private async loadRemovedGroupMembersWithPagination(provider: string, name: string, offset: number, to: number): Promise<number[]> {
-        return [];
+        let indexesOfDeletedMembers: number[] = [];
+
+        const limit: number = 100;
+
+        let indexes: number[] = await interRepFunctions.getRemovedMembersForGroup(this.config.interepUrl, provider, name, limit, offset);
+
+        indexesOfDeletedMembers = indexesOfDeletedMembers.concat(indexes);
+
+        while (indexes.length + limit <= to) {
+            offset += limit;
+            indexes = await interRepFunctions.getRemovedMembersForGroup(this.config.interepUrl, provider, name, limit, offset);
+            indexesOfDeletedMembers = indexesOfDeletedMembers.concat(indexes);
+        }
+
+        return indexesOfDeletedMembers;
     }
 
     private async continuousSync() {

--- a/zk-chat-server-lib/src/semaphore/api.ts
+++ b/zk-chat-server-lib/src/semaphore/api.ts
@@ -1,37 +1,40 @@
-// Copy the server-lib interep impementation to a pcd implementation that fetches https://api.pcd-passport.com/semaphore/1 instead of the interep api.
-
 import axios from 'axios';
-import { IGroupMember, ISemaphoreRepGroupV2 } from "./interfaces";
+import { IGroupMember, IInterRepGroupV2 } from "./interfaces";
+import { Group } from "@semaphore-protocol/group";
+
+const DEFAULT_DEPTH = 16
+const DEFAULT_GROUP_ID = "1"
 
 /**
  * Returns only the supported groups
  */
-const getAllGroups = async (baseUrl: string): Promise<ISemaphoreRepGroupV2[]> => {
-    // TODO: create a new endpoint in the zupass api that returns only the supported groups
+const getAllGroups = async (baseUrl: string): Promise<IInterRepGroupV2[]> => {
+    const membersRaw = await getMembersForGroup(baseUrl);
+    const members = membersRaw.map((member: IGroupMember) => member.identityCommitment);
+    const group = new Group(DEFAULT_GROUP_ID, DEFAULT_DEPTH);
+    group.addMembers(members);
+    const merkleRoot = String(group.root);
+    console.log("!@# getAllGroups: members.length=", members.length, ", merkleRoot=", merkleRoot);
     return [
         {
-            id: '1',
+            root: merkleRoot,
             name: 'Zuzalu Participants',
-            deep: 16,
+            provider: "Semaphore",
+            // NOTE: (Kevin) size and number of leaves are the same since
+            // members should not be removed in Zuzalu?
+            size: members.length,
+            numberOfLeaves: members.length,
         },
-        // {
-        //     id: '2',
-        //     name: 'Zuzalu Residents',
-        //     deep: 16,
-        // },
-        // {
-        //     id: '3',
-        //     name: 'Zuzalu Visitors',
-        //     deep: 16,
-        // }
     ]
 };
 
 /**
  * Returns an ordered list of members in the group.
  */
-const getMembersForGroup = async (baseUrl: string, id: string): Promise<IGroupMember[]> => {
+const getMembersForGroup = async (baseUrl: string): Promise<IGroupMember[]> => {
+    const id = DEFAULT_GROUP_ID
     const url = baseUrl + `/semaphore/${id}`;
+    console.log("!@# getMembersForGroup: url = ", url)
     try {
         const res = await axios({
             method: 'GET',
@@ -58,32 +61,9 @@ const getMembersForGroup = async (baseUrl: string, id: string): Promise<IGroupMe
 /**
  * Returns an ordered list of the leaf indexes of removed members in the group.
  */
-const getRemovedMembersForGroup = async (baseUrl: string, id: string): Promise<number[]> => {
-    const url = baseUrl + `/semaphore/${id}`;
-    try {
-        const res = await axios({
-            method: 'GET',
-            timeout: 5000,
-            url,
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-            }
-        });
-        // TODO: ask if this is the right way to detect removed members
-        const removedMembers: number[] = res.data.members
-            .filter((member:string) => member === '00000000000000000000000000000000000000000000000000000000000000000000000000000')
-            .map((member: string, index: number) => {
-                return {
-                    index,
-                    identityCommitment: member
-                }
-            })
-        return removedMembers;
-    } catch (e) {
-        console.log("Exception while loading removed members of the group: ", id);
-        return [];
-    }
+const getRemovedMembersForGroup = async (baseUrl: string): Promise<number[]> => {
+    // NOTE: (Kevin) I don't think we need this function for Zuzalu
+    return [];
 }
 
 const apiFunctions = {

--- a/zk-chat-server-lib/src/semaphore/interfaces.ts
+++ b/zk-chat-server-lib/src/semaphore/interfaces.ts
@@ -1,14 +1,16 @@
-export interface ISemaphoreRepGroup {
+export interface IInterRepGroup {
     id: string;
     provider: string;
     name: string;
     size: number;
 }
 
-export interface ISemaphoreRepGroupV2 {
-    id: string;
+export interface IInterRepGroupV2 {
+    root: string;
+    provider: string;
     name: string;
-    deep: number;
+    size: number;
+    numberOfLeaves: number;
 }
 
 export interface IGroupMember {

--- a/zk-chat-server-lib/tests/interrep/api.test.ts
+++ b/zk-chat-server-lib/tests/interrep/api.test.ts
@@ -45,10 +45,10 @@ describe('Test interrep sync - subgraph', () => {
             }
         ];
 
-        mockAxios.mockResolvedValue({
+        mockAxios.mockResolvedValue({ 
             data: {
                 data: testGroups
-            }
+            } 
         });
 
         const groups: any[] = await apiFunctions.getAllGroups(baseURL);
@@ -67,7 +67,7 @@ describe('Test interrep sync - subgraph', () => {
             }
         });
 
-        const members: IGroupMember[] = await apiFunctions.getMembersForGroup(baseURL);
+        const members: IGroupMember[] = await apiFunctions.getMembersForGroup(baseURL, "twitter", "not_sufficient");
         expect(members.length).toEqual(6);
         expect(members[0]).toEqual({ index: 0, identityCommitment: 'id-0' });
         expect(members[1]).toEqual({ index: 1, identityCommitment: 'id-1' });
@@ -83,7 +83,7 @@ describe('Test interrep sync - subgraph', () => {
             }
         });
 
-        const removedIndexes: number[] = await apiFunctions.getRemovedMembersForGroup(baseURL);
+        const removedIndexes: number[] = await apiFunctions.getRemovedMembersForGroup(baseURL, "twitter", "not_sufficient");
         expect(removedIndexes.length).toEqual(3);
         expect(removedIndexes[0]).toEqual(0);
         expect(removedIndexes[1]).toEqual(1);

--- a/zk-chat-server-lib/tests/interrep/synchronizer.test.ts
+++ b/zk-chat-server-lib/tests/interrep/synchronizer.test.ts
@@ -70,7 +70,7 @@ const getMembersForGroupMock = async (baseUrl: string, provider: string, name: s
     testMembers_g3[21].identityCommitment = "0";
     testMembers_g3[30].identityCommitment = "0";
     testMembers_g3[45].identityCommitment = "0";
-
+    
     if (provider == 'github' && name == 'GOLD')
         return testMembers_g1;
     else if (provider == 'twitter' && name == 'GOLD')
@@ -100,8 +100,8 @@ describe('Test interrep synchronizer', () => {
         userService = new UserService(ZKServerConfigBuilder.get().build());
 
         subgraphFunctions.getAllGroups = getAllGroupsMock;
-        //subgraphFunctions.getMembersForGroup = getMembersForGroupMock;
-        //subgraphFunctions.getRemovedMembersForGroup = getRemovedMembersForGroupMock;
+        subgraphFunctions.getMembersForGroup = getMembersForGroupMock;
+        subgraphFunctions.getRemovedMembersForGroup = getRemovedMembersForGroupMock;
 
         synchronizer = new InterRepSynchronizer(testPubSub, groupService, userService, ZKServerConfigBuilder.get().build());
     })

--- a/zk-chat-server-lib/tests/services/key_exchange_service.test.ts
+++ b/zk-chat-server-lib/tests/services/key_exchange_service.test.ts
@@ -20,7 +20,7 @@ describe('Test key exchange service', () => {
 
     let keyExchangeService: KeyExchangeService;
 
-    const timestampTodayMs = 1637837920000;
+    const timestampTodayMs = 1639339300000;
 
     const epoch = BigInt(123);
     const rlnIdentifier = BigInt(456);

--- a/zk-chat-server-lib/tests/services/message_handle.service.test.ts
+++ b/zk-chat-server-lib/tests/services/message_handle.service.test.ts
@@ -24,7 +24,7 @@ describe('Test message handle service', () => {
 
     let messageHandlerService: MessageHandlerService;
 
-    const timestampTodayMs = 1637837920000;
+    const timestampTodayMs = 1639339300000;
 
     const publicSignals: RLNPublicSignals = {
         yShare: BigInt(123).toString(),


### PR DESCRIPTION
## What's done?
- Move semaphore-only logic to semaphore syncer, and recover interrep syncer
- Fix tests broken because we've increased "seconds per epoch" from 10 seconds to 100 seconds, to make testing spam easier