### PR TITLE
Support deploy for dev environment

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -x
- 
+
+environment=$1
+
 COMMIT_HASH=$(git rev-parse HEAD)
-DEPLOY_ID=$(aws deploy create-deployment --application-name zkchat --deployment-group-name zkchat-group --github-location repository=$GITHUB_REPOSITORY,commitId=$COMMIT_HASH --ignore-application-stop-failures --file-exists OVERWRITE --output text)
+DEPLOY_ID=$(aws deploy create-deployment --application-name zkchat-$environment --deployment-group-name zkchat-$environment-group --github-location repository=$GITHUB_REPOSITORY,commitId=$COMMIT_HASH --ignore-application-stop-failures --file-exists OVERWRITE --output text)
 
 while true; do
   STATUS=$(aws deploy get-deployment --deployment-id $DEPLOY_ID --query 'deploymentInfo.status' --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,14 @@ on:
         options:
         - enable
         - disable
+      environment:
+        description: "Environment"
+        required: true
+        default: "enable"
+        type: choice
+        options:
+        - prod
+        - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATA: ${{ github.event.inputs.build }}
+      DATA_ENV: ${{ github.event.inputs.environment }}
     permissions:
       id-token: write
       contents: read
@@ -32,6 +41,15 @@ jobs:
         with:
           persist-credentials: false
           
+      - name: Check branch and environment
+        run: |
+          if [ "${{ env.DATA_ENV }}" = "prod" ]; then
+            if [ "$GITHUB_BASE_REF" != "main" ]; then
+              echo "Operation not permitted"
+              exit 1
+            fi
+          fi
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -45,4 +63,4 @@ jobs:
 
       - name: Create Deployment
         run: |
-          .github/scripts/deploy.sh
+          .github/scripts/deploy.sh ${{ env.DATA_ENV }}


### PR DESCRIPTION
This PR enables deployment against a new instance on AWS, that will be used for zk-chat development.

Changes:
- Modified the deploy workflow to support environment inputs and added an extra step that avoids production deployment using any other branch except main.
- Modified the script that triggers code-deploy,  to support multiple environments.